### PR TITLE
fix rstcheck usage

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -x
           python3 copyreplace.py *.rst
-          rstcheck --ignore-language c,c++ --report warning *.rep
+          rstcheck --ignore-languages c,c++ --report-level warning *.rep
           rm -f *.rep
 
       - name: Build web documentation


### PR DESCRIPTION
This is a cherry-pick from apptainer/apptainer-userdocs#103.  It fixes these errors seen in the rstcheck CI test here:
```
Error: No such option: --ignore-language (Possible options: --ignore-languages, --ignore-messages, --ignore-roles)
```
```
Error: No such option: --report Did you mean --report-level?
```
