### PR TITLE
Describe automated rpm import of singularity config

### DIFF
--- a/configfiles.rst
+++ b/configfiles.rst
@@ -1043,11 +1043,26 @@ This flag controls HTTP vs HTTPS for service discovery only. The
 protocol used to access individual library, build and keyserver URLs is
 set by the service discovery file.
 
+.. _no_default_remote:
+
 Restoring pre-{Project} library behavior
 ----------------------------------------
 
-These are the commands to restore the library behavior from before
-{Project}, where using the `library://` URI would download from the
+{Project}'s default remote endpoint configures only a public key
+server, it does not support the ``library://`` protocol.
+Formerly the default was set to point to Sylabs servers, but the 
+read/write support of the ``oras://`` protocol by for example the
+`GitHub Container Registry
+<{userdocs}/docker_and_oci.html#github-container-registry>`_
+makes it unnecessary.
+The remote endpoint was also formerly used for builds using the
+build ``--remote`` option, but {Project} does not support that.
+Instead, it supports
+`unprivileged local builds <{userdocs}/fakeroot.html#build>`_.
+
+If you would still like to have the previous default for all users,
+these are the commands to restore the library behavior from before
+{Project}, where using the ``library://`` URI would download from the
 Sylabs Cloud anonymously:
 
 .. code::

--- a/singularity_migration.rst
+++ b/singularity_migration.rst
@@ -12,54 +12,65 @@ the move, please reach out to the `community <https://apptainer.org/help>`_ so
 we can help you!
 
 
-When migrating to {Project} from Singularity, Administrators that have
+When migrating to {Project} from Singularity, administrators that have
 modified the system configurations of their installation and want {Project}
-to have identical configuration will need to migrate the configurations they have
-in place for Singularity to {Project} either manually or with configuration
-management tools.
+to have identical configuration will need to migrate the configurations they
+have in place for Singularity to {Project}.
+An exception is an RPM update from an already-installed singularity package;
+in that case, the RPM will automatically import the old configuration,
+but an administrator should verify the conversion.
 
-All system configuration files are typically located in ``/etc/singularity`` or
-``/usr/local/etc/singularity`` when installed from a RPM/Deb package or source
-respectively, but options passed during source installations could cause this to
-be in another location. {Project} will store its configurations in similar
-locations, but within a directory named ``{command}`` directory instead of
-``singularity``.
+All singularity system configuration files are typically located under
+``/etc/singularity`` or ``/usr/local/etc/singularity``
+when installed from a RPM/Deb package or source respectively,
+but options passed during source installations could cause this to
+be in another location.
+{Project} will store its configurations in similar locations, but within
+a directory named ``{command}`` instead of ``singularity``.
+
+.. note::
+
+    The ``singularity`` configuration directory at the prefix corresponding to
+    your ``{command}`` configuration directory (e.g. ``/etc/singularity`` or
+    ``/usr/local/etc/singularity``) needs to be manually removed to prevent
+    {Project} from producing a message at runtime about the cleanup being
+    incomplete.
 
 All system configuration names, file formats, and parameters for {Project} are
 identical to their Singularity counterparts with the exception of
 ``singularity.conf``, which has been renamed to ``{command}.conf`` as a part of
-the project renaming. It is important to note that comments within some of the
-configuration files have been changed with the rename as well. So, while you can
-copy files around, we **recommend** applying the same configuration changes to
-the new files instead of simply copying contents.
+the project renaming.  It is important to note that comments within 
+``{command}.conf`` have been changed and the default contents of
+``remote.yaml`` has changed.
+So, while you can copy files around, we **recommend** applying the same
+configuration changes to the new files instead of simply copying
+contents.
 
 .. warning::
 
     Take care to not wipe out all configuration in the {Project} config
     directory as a part of your migration because it will remove configuration
     files that are new to the project like configurations for
-    :ref:`checkpointing <dmtcp_configuration>`
+    :ref:`checkpointing <dmtcp_configuration>`.
 
-
-If you are migrating from an installation with default configuration, you do not
-need to perform any configuration migration as {Project} defaults have not been
-changed.
-
-.. note::
-
-    The ``singularity`` configuration directory at the prefix corresponding to
-    your ``{command}`` configuration directory (e.g. ``/etc/singularity`` or
-    ``/usr/local/etc/singularity``) needs to be removed to prevent {Project}
-    from producing a warning at runtime about the migration being incomplete.
+If you are migrating from an installation with default configuration,
+there is no need to perform any configuration migration.
 
 However, a big change from Singularity is that {Project} does not
 install a setuid-root component by default.  That means that either
 user namespaces needs to be enabled or the setuid-root component needs
 to be installed separately.  See the 
-:ref:`User Namespaces & Fakeroot <userns>` section
+:ref:`User Namespaces & Fakeroot <userns>` section,
 or to find out about how to install the setuid-root component see the
 :ref:`Installation <installation>` section.
+An exception is with RPM packaging when updating from the
+``singularity`` package: that case installs the ``{command}-suid``
+package by default, but since setuid-root is a higher security risk,
+consider removing that package after upgrade.
 
 Also see the user guide documentation about `Singularity compatibility
 <{userdocs}/singularity_compatibility.html>`__ for information about how the
 migration to {Project} will impact users.
+In particular the system administrator may want to 
+:ref:`restore pre-Apptainer library behavior <no_default_remote>`
+for all users.


### PR DESCRIPTION
This updates the discussion of singularity migration to match apptainer/apptainer#969 which will go into apptainer-1.1.5.  This should be cherry-picked to the 1.1 branch after 1.1.5 is released.

It also updates the discussion of the default remote endpoint similarly to apptainer/apptainer-userdocs#150.