### PR TITLE
Add SUSE to the list of OSes supported by install-unprivileged.sh (1.1)

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -248,8 +248,8 @@ Install unprivileged from pre-built binaries
 
 A script is available to make a relocatable unprivileged binary installation 
 of {Project}, including all dependencies that are not normally installed
-on Linux systems.  The script works on Red Hat Enterprise Linux-derived
-systems, Fedora, Debian, and Ubuntu.
+on Linux systems.  The script works on current Red Hat Enterprise Linux-derived
+systems, Fedora, SUSE/OpenSUSE, Debian, and Ubuntu.
 
 This is the easiest way to use it:
 


### PR DESCRIPTION
This cherry-picks #89 to the 1.1 branch.