### PR TITLE
Clarify the availability of non-subuid mapped fakeroot

### DIFF
--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -139,7 +139,7 @@ See details in the
 of the user guide.
 
 The most complete method of emulating running as root, the method used
-for example by Podman and also commonly referred to as "rootless mode",
+for example by Podman and also commonly referred to as "rootless" mode,
 requires administrator setup and also requires some assistance from an
 enhanced-privilege program.
 The rest of the documentation on this page describes how to do that
@@ -147,7 +147,12 @@ setup.
 If this setup is done, {Project} will take advantage of it and use
 it, otherwise it will try to use one of its other methods when the
 ``--fakeroot`` option is used.
-The other methods do not require any special administrator setup.
+The other methods do not require any special administrator setup,
+so they actually use less privileges than the mode commonly called
+"rootless" described below.
+Again, the details of those other methods are in the
+`Fakeroot feature section <{userdocs}/fakeroot.html>`_
+of the user guide.
 
 This mode not only maps the root user to the original unprivileged
 user, but it also maps many additional UIDs and GIDs to otherwise 


### PR DESCRIPTION
Somebody reported being confused by this section, and this is an attempt to clarify.