### PR TITLE
Edits, from sylabs 88

### DIFF
--- a/configfiles.rst
+++ b/configfiles.rst
@@ -677,6 +677,9 @@ filesystem and by checking against a list of signing entities.
    types (squashfs/extfs/dir) via the ``{command}.conf`` file ``allow
    container`` settings.
 
+   In an unprivileged installation of {Project}, a user can specify their
+   own ``{command}.conf`` via ``--config``, and bypass ECL restrictions.
+
 .. code::
 
    [[execgroup]]


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-admindocs#88

The original PR description was:
> * Mention proot, OCI functionality.
> * Tweak explanation of implications of unprivileged install / userns.
> * Highlight effect on security restrictions of unprivileged install.