### PR TITLE
Show how to use apptainer from the lima host

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -620,3 +620,14 @@ To use Lima via Homebrew:
 Then do ``limactl start template://apptainer`` and ``limactl shell apptainer``.
 
 See the `lima apptainer template <https://github.com/lima-vm/lima/blob/master/examples/apptainer.yaml>`_ for more details.
+
+To use Lima from the host:
+
+.. code::
+
+   $ apptainer run docker://ghcr.io/apptainer/lolcow  ## link to "apptainer.lima"
+   $ apptainer build /tmp/lima/lolcow_latest.sif docker://ghcr.io/apptainer/lolcow
+
+For large images, it is faster to use a local filesystem (like is done for the cache).
+
+By default, the home directory (``$HOME``) is mounted as read-only but there is a shared writable directory mounted in ``/tmp/lima``.


### PR DESCRIPTION
## Description of the Pull Request (PR):

While it is possible to shell into the virtual machine, it is also possible to call `apptainer.lima` on the host.

This makes it easier to interact with the local files, and to copy the resulting SIF files to another location.

While Lima commands are shown for the Mac, they also work the same way on a host running Linux.

You can use `brew` to install it also on Linux, or you can use the package manager to install `limactl`...

## This fixes or addresses the following GitHub issues:

Follow up to PR:

* #74
