### PR TITLE
Fix for two 404 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a community project maintained as a sub-project by the
 and contributions are always welcome! If you'd like to update or improve
 Apptainer's documentation please read the
 [Apptainer CONTRIBUTING
-file](https://github.com/apptainer/apptainer/CONTRIBUTING.md),
+file](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md),
 follow the instructions below, and submit a PR on GitHub.
 
 This project uses [reStructured Text (RST)](http://docutils.sourceforge.net/rst.html)

--- a/installation.rst
+++ b/installation.rst
@@ -586,7 +586,7 @@ Use ``vagrant init`` to create a new Vagrantfile, or use this example:
 
    Vagrant.configure("2") do |config|
      # Choose operating system distribution
-     config.vm.box = "fedora/36-cloud-base"
+     config.vm.box = "fedora/38-cloud-base"
 
      config.vm.provider "virtualbox" do |vb|
        # Customize the number of cpus on the VM:


### PR DESCRIPTION
## Description of the Pull Request (PR):

The README has an incorrect link to the Apptainer CONTRIBUTING documentation, and the Vagrantfile example for running Apptainer on Mac has an outdated version of Fedora 36 Cloud that isn't available anymore. This PR corrects those links.


## This fixes or addresses the following GitHub issues:

- See above
