### PR TITLE
Updates for use of FUSE in suid mode

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -36,14 +36,13 @@ Full functionality of {Project} requires that the kernel supports:
 -  **Unprivileged user namespaces** - (minimum kernel >=3.8, >=4.18
    or 3.10.0-1127 on RHEL7 recommended)
    Required to run containers without root or setuid privilege.
-   The recommended versions are required for unprivileged SIF file
-   mounts.
+   The recommended versions are required for unprivileged FUSE mounts.
 
 -  **OverlayFS mounts** - (minimum kernel >=3.18, >=5.11 recommended)
-   Required for full flexibility in bind mounts to containers in suid
-   mode, and to support persistent overlays for writable containers
-   in suid mode.  Kernel 5.11 enables support for persistent overlay
-   unprivileged, but otherwise fuse-overlayfs will be used for that.
+   Used for creating missing bind mount paths and for writable overlays.
+   Kernel 5.11 enables support for overlays unprivileged, but whenever
+   the kernel OverlayFS driver doesn't work, fuse-overlayfs will be used
+   instead.
 
 Instructions to install without or with setuid privileges are below.
 Please make sure you are familiar with the discussion on

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -34,9 +34,11 @@ required, with >=4.18 being recommended due to support for unprivileged
 mounting of FUSE filesystems (needed for example for mounting SIF files).
 The equivalent recommendation on RHEL7 is >=3.10.0-1127 from release
 7.8, where unprivileged mounting of FUSE filesystems was backported.
-To use unprivileged overlayFS for persistent overlays, kernel >=5.11 is
-recommended, but if that's not available then {Project} will use
-fuse-overlayfs instead.  That feature has not been backported to RHEL7.
+To use unprivileged overlayFS for creating missing bind mount paths and
+for writable overlays, kernel >=5.11 is recommended.
+That feature has not been backported to RHEL7.
+Whenever the kernel overlayFS doesn't work then {Project} will use
+fuse-overlayfs instead.  
 
 Additionally, some Linux distributions require that unprivileged user
 namespace creation is enabled using a ``sysctl`` or kernel command line


### PR DESCRIPTION
Make the kernel requirement descriptions match apptainer-1.3.0's usage.
- Continuation of apptainer/apptainer-userdocs#240