### PR TITLE
add uts|usr ns|ipc flags in apptainer.conf

### DIFF
--- a/configfiles.rst
+++ b/configfiles.rst
@@ -91,6 +91,17 @@ namespace when running their containers through the ``--pid`` flag.
    Using the PID namespace can confuse the process tracking of some
    resource managers, as well as some MPI implementations.
 
+``allow user ns``: This option controls the creation of user namespaces. If
+set to ``no``, this will prevent execution of containers with the ``--userns``
+or ``--fakeroot`` flags, and unprivileged installations of {Project}.
+
+``allow uts ns``: Likewise, this option determines whether users can make use
+of the UTS namespace when running their containers. If sets to ``no``, it
+disables the ``--uts`` and ``--hostname`` flags.
+
+``allow ipc ns``: Likewise, this option determines whether users can request
+the IPC namespace. If sets to ``no``, it disable the use of the ``--ipc`` flag.
+
 Configuration Files
 ===================
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

add uts|usr ns|ipc flags in apptainer.conf

## This fixes or addresses the following GitHub issues:

- Fixes apptainer/apptainer-userdocs#317
