### PR TITLE
add --netns-path for admindocs

### DIFF
--- a/configfiles.rst
+++ b/configfiles.rst
@@ -345,6 +345,11 @@ execution where only 40_fakeroot.conflist is used.
 that may be used by users and groups listed in the allow net users /
 allow net groups directives.
 
+``allow netns paths``: Specify the paths to network namespaces that may 
+be joined by users and groups listed in the allow net users / allow net 
+groups directives. This restriction only applies when {Project} is 
+running in SUID mode and the user is non-root.
+
 GPU Options
 ===========
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

add --netns-path for admindocs


## This fixes or addresses the following GitHub issues:

- Fixes https://github.com/apptainer/apptainer-userdocs/issues/315
