### PR TITLE
Updates to Lima apptainer information for the new versions

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -707,9 +707,8 @@ for more details.
 
 By default, the host home directory is mounted as read-only in the guest,
 so you need to add a shared writable directory mount if you want output
-that can be accessed both from the host and in the guest.
-
-Previously there was a mount in `/tmp/lima`, it was removed in Lima 2.0.
+that can be accessed both from the host and in the guest (see ``--mount``).
+If you want to mount it as read-write, use the flag: ``--mount-writable``.
 
 GPU Support
 ^^^^^^^^^^^

--- a/installation.rst
+++ b/installation.rst
@@ -718,7 +718,8 @@ Lima supports using an Apple GPU from the Linux environment, with `krunkit <http
 
 .. code:: console
 
-    $ brew tap slp/krunkit
+    $ brew tap libkrun/krun
+    $ brew trust libkrun/krun
     $ brew install krunkit
     $ limactl start --vm-type=krunkit template:apptainer
 

--- a/installation.rst
+++ b/installation.rst
@@ -723,14 +723,6 @@ Lima supports using an Apple GPU from the Linux environment, with `krunkit <http
     $ brew install krunkit
     $ limactl start --vm-type=krunkit template:apptainer
 
-For now you need to install `mesa-vulkan-drivers` from the `mesa-krunkit <https://launchpad.net/~step22/+archive/ubuntu/mesa-krunkit>`_ PPA:
-
-.. code:: shell
-
-    sudo add-apt-repository ppa:step22/mesa-krunkit
-    sudo apt update
-    sudo apt install -y vulkan-tools mesa-vulkan-drivers=24*
-
 After that, you should have full access to ``/dev/dri`` also from the containers:
 
 .. code:: console

--- a/installation.rst
+++ b/installation.rst
@@ -710,6 +710,12 @@ so you need to add a shared writable directory mount if you want output
 that can be accessed both from the host and in the guest (see ``--mount``).
 If you want to mount it as read-write, use the flag: ``--mount-writable``.
 
+To run {Project} from the host, you can use the ``apptainer.lima`` wrapper.
+For easier access, you can alias or symlink it to the ``apptainer`` command.
+
+See the `"run-singularity" script <https://github.com/apptainer/apptainer/blob/main/scripts/run-singularity>`_
+for running SIF files.
+
 GPU Support
 ^^^^^^^^^^^
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The instructions for GPU support was updated:
https://github.com/libkrun/krunkit

* The old homebrew tap for krunkit was renamed
* The mesa-vulkan-drivers backport is not needed

Also show more Lima information, similar to AC:

* Show how to mount Lima host home as read-write
* Add information about the Lima scripts too

## This fixes or addresses the following GitHub issues:

Fixes #244

----

Also needs this workaround, to go in the Lima template:

`APPTAINER_TMPDIR=/var/tmp` (due to systemd version 259)

https://github.com/systemd/systemd/commit/c397b5c7018948b652312f5fa97839cab5be8e49

https://github.com/systemd/systemd/commit/7cf0efd8ecc45694d64e42bc244fd477d11644c8
